### PR TITLE
Use io.ReadAll instead of ioutil.ReadAll

### DIFF
--- a/tiktok.go
+++ b/tiktok.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -59,7 +59,7 @@ func (s *TikTokService) Embed(params map[string]string) (*Response, error) {
 	}
 
 	defer resp.Body.Close()
-	respBody, err := ioutil.ReadAll(resp.Body)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Package [`io/ioutil`](https://golang.org/pkg/io/ioutil/) [has been deprecated since 1.16](https://golang.org/doc/go1.16#ioutil). I've changed call `ioutil.ReadAll` to `io.ReadAll`.